### PR TITLE
chore: add goreleaser to create assets when tagging

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,40 @@
+project_name: send-alb-metrics-to-datadog
+env:
+  - GO111MODULE=on
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - main: main.go
+    binary: send-alb-metrics-to-datadog
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+      - -X main.Revision={{.ShortCommit}}
+    env:
+      - CGO_ENABLED=0
+archives:
+  - id: build
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+    files:
+        - README.md
+    format_overrides:
+      - goos: Windows
+        format: zip
+release:
+  prerelease: auto
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'


### PR DESCRIPTION
This PR adds configure goreleaser to create assets when tagging. Because I want to use binary to deploy lambda function via lambroll.