### PR TITLE
chore: add steps for goreleaser

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -26,6 +26,17 @@ jobs:
           registry: ghcr.io
           username: reproiobot
           password: ${{ secrets.CR_PAT }}
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.21
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v3
         with:
           context: .


### PR DESCRIPTION
I added configuration file for goreleaser at https://github.com/reproio/send-alb-metrics-to-datadog/pull/32. But I forgot to add steps into release workflow.