### PR TITLE
fix: build failure

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ before:
   hooks:
     - go mod tidy
 builds:
-  - main: main.go
+  - main: .
     binary: send-alb-metrics-to-datadog
     ldflags:
       - -s -w


### PR DESCRIPTION
goreleaser failed after merging https://github.com/reproio/send-alb-metrics-to-datadog/pull/37 and https://github.com/reproio/send-alb-metrics-to-datadog/pull/38 . I fix it.

```
  ⨯ release failed after 1m33s               error=failed to build for linux_arm64: exit status 1: # command-line-arguments
Error: ./main.go:26:20: undefined: NewProcessor
Error: ./main.go:48:20: undefined: NewProcessor

Error: The process '/opt/hostedtoolcache/goreleaser-action/1.23.0/x64/goreleaser' failed with exit code 1
```