### PR TITLE
fix: need to fetch tags to use goreleaser

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Fetch all tags
+        run: git fetch --force --tags
       - uses: docker/login-action@v1
         with:
           registry: ghcr.io


### PR DESCRIPTION
The release workflow runs, but goreleaser didn't release. Because goreleaser can't get tags information:

```
  • getting and validating git state
    • ignoring errors because this is a snapshot     error=git doesn't contain any tags. Either add a tag or use --snapshot
    • git state                                      commit=ce226beb2021a5e9f9656e441848611e164617e6 branch=main current_tag=v0.0.0 previous_tag=<unknown> dirty=false
    • pipe skipped                                   reason=disabled during snapshot mode
```

So this PR adds to fetch tags.