### PR TITLE
support disabling to submit request count metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - uses: actions/checkout@v4
+      - run: make build
+      - run: make test

--- a/metrics_submitter.go
+++ b/metrics_submitter.go
@@ -59,15 +59,17 @@ func (p *MetricsSubmitter) Submit(metrics map[string]*Metric, s3ObjectKey string
 			return nil
 		})
 
-		eg.Go(func() error {
-			_, r, err := v2Api.SubmitMetrics(ctx, metricsPayload, *datadogV2.NewSubmitMetricsOptionalParameters())
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error when calling `MetricsApi.SubmitMetrics`: %v\n", err)
-				fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-				return err
-			}
-			return nil
-		})
+		if p.requestCountMetricName != "" {
+			eg.Go(func() error {
+				_, r, err := v2Api.SubmitMetrics(ctx, metricsPayload, *datadogV2.NewSubmitMetricsOptionalParameters())
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Error when calling `MetricsApi.SubmitMetrics`: %v\n", err)
+					fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+					return err
+				}
+				return nil
+			})
+		}
 	}
 
 	if err := eg.Wait(); err != nil {

--- a/metrics_submitter.go
+++ b/metrics_submitter.go
@@ -43,7 +43,7 @@ func (p *MetricsSubmitter) Submit(metrics map[string]*Metric, s3ObjectKey string
 		}
 
 		distributionPointPayload := datadogV1.DistributionPointsPayload{}
-		s, err := p.targetProcessingTime(metric)
+		s, err := p.targetProcessingTime(metric, s3ObjectKey)
 		if err != nil {
 			return err
 		}
@@ -107,7 +107,7 @@ func (p *MetricsSubmitter) requestCountSeries(metric *Metric, s3ObjectKey string
 	return *series
 }
 
-func (p *MetricsSubmitter) targetProcessingTime(metric *Metric) ([]datadogV1.DistributionPointsSeries, error) {
+func (p *MetricsSubmitter) targetProcessingTime(metric *Metric, s3ObjectKey string) ([]datadogV1.DistributionPointsSeries, error) {
 	seriesSlice := make([]datadogV1.DistributionPointsSeries, 1)
 	points := make([][]datadogV1.DistributionPointItem, 0, len(metric.TargetProcessingTimesMap))
 
@@ -127,6 +127,7 @@ func (p *MetricsSubmitter) targetProcessingTime(metric *Metric) ([]datadogV1.Dis
 		fmt.Sprintf("elb_status_code:%s", metric.ElbStatusCode),
 		fmt.Sprintf("target_status_code:%s", metric.TargetStatusCode),
 		fmt.Sprintf("target_status_code_group:%s", metric.TargetStatusCodeGroup()),
+		fmt.Sprintf("ip_address:%s", p.loadBalancerIpAddress(s3ObjectKey)),
 	}
 	for _, tag := range p.customTags {
 		tags = append(tags, fmt.Sprintf("%s:%s", tag.Name, tag.Key()))

--- a/metrics_submitter_test.go
+++ b/metrics_submitter_test.go
@@ -105,6 +105,7 @@ func TestMetricsSubmitter_targetProcessingTime(t *testing.T) {
 						"elb_status_code:200",
 						"target_status_code:200",
 						"target_status_code_group:2xx",
+						"ip_address:172.160.001.192",
 					},
 					Type: &typeVar,
 				},
@@ -119,7 +120,7 @@ func TestMetricsSubmitter_targetProcessingTime(t *testing.T) {
 				targetProcessingTimeMetricName: tt.fields.TargetProcessingTimeMetricName,
 				customTags:                     tt.fields.CustomTags,
 			}
-			got, err := p.targetProcessingTime(tt.args.metric)
+			got, err := p.targetProcessingTime(tt.args.metric, "s3://my-bucket/my-prefix/AWSLogs/123456789012/elasticloadbalancing/us-east-2/2022/05/01/123456789012_elasticloadbalancing_us-east-2_app.my-loadbalancer.1234567890abcdef_20220215T2340Z_172.160.001.192_20sg8hgm.log.gz")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("targetProcessingTime() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
This PR supports to disable submitting request count metrics. Because we can count by target_processing_time_metrics. 

If you don't add request_count_metrics_name in config file, don't submit metrics.
