### PR TITLE
Set target status code group to "-"

### DIFF
--- a/log_file_reader.go
+++ b/log_file_reader.go
@@ -118,7 +118,9 @@ type Metric struct {
 }
 
 func (m *Metric) TargetStatusCodeGroup() string {
-	code := ""
+	// TargetStatusCode is - when the target does not send a response
+	// see: https://docs.aws.amazon.com/ja_jp/elasticloadbalancing/latest/application/load-balancer-access-logs.html
+	code := "-"
 	switch {
 	case strings.HasPrefix(m.TargetStatusCode, "1"):
 		code = "1xx"

--- a/metrics_submitter_test.go
+++ b/metrics_submitter_test.go
@@ -112,6 +112,53 @@ func TestMetricsSubmitter_targetProcessingTime(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "TargetStatusCode is -",
+			fields: fields{
+				TargetProcessingTimeMetricName: "target_processing_time",
+			},
+			args: args{
+				metric: &Metric{
+					TargetProcessingTimesMap: map[Timestamp]TargetProcessingTimes{
+						Timestamp(1): {-1},
+						Timestamp(2): {-1},
+					},
+					Method:           "GET",
+					Path:             "/",
+					ElbStatusCode:    "460",
+					TargetStatusCode: "-",
+					Elb:              "elb",
+					TargetGroupArn:   "arn",
+				},
+			},
+			want: []datadogV1.DistributionPointsSeries{
+				datadogV1.DistributionPointsSeries{
+					Metric: "target_processing_time",
+					Points: [][]datadogV1.DistributionPointItem{
+						{
+							{DistributionPointTimestamp: datadog.PtrFloat64(1)},
+							{DistributionPointData: &[]float64{-1}},
+						},
+						{
+							{DistributionPointTimestamp: datadog.PtrFloat64(2)},
+							{DistributionPointData: &[]float64{-1}},
+						},
+					},
+					Tags: []string{
+						"elb:elb",
+						"target_group_arn:arn",
+						"path:/",
+						"method:GET",
+						"elb_status_code:460",
+						"target_status_code:-",
+						"target_status_code_group:-",
+						"ip_address:172.160.001.192",
+					},
+					Type: &typeVar,
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Set the target status code group to "-" when the target status code is "-" because Datadog does not accept empty tag values.