### PR TITLE
Group GitHub Actions dependency updates into a single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Reduce PR noise by consolidating all GitHub Actions dependency updates into one PR instead of one per action

## Changes
- Add `packageRules` to `renovate.json` with `matchManagers: ["github-actions"]` and `groupName: "github actions"`

## Testing
- No functional code changes; Renovate will apply the new grouping on its next run