### PR TITLE
Group Go version updates into a single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,11 @@
     {
       "matchManagers": ["github-actions"],
       "groupName": "github actions"
+    },
+    {
+      "matchManagers": ["gomod", "github-actions"],
+      "matchDepTypes": ["golang", "go-version"],
+      "groupName": "go version"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Reduce PR noise by consolidating Go version bumps across `go.mod` and GitHub Actions workflows into one PR

## Changes
- Add `packageRule` to `renovate.json` matching `gomod` and `github-actions` managers with `depTypes` `golang` and `go-version`, grouped as "go version"

## Testing
- No functional code changes; Renovate will apply the new grouping on its next run